### PR TITLE
Restore the "listing" tool

### DIFF
--- a/controllers/templates/templates.go
+++ b/controllers/templates/templates.go
@@ -67,6 +67,6 @@ func Init(g config.Getter) {
 
 	root := g.StringDefault("root.directory", "./")
 	views := g.StringDefault("views.directory", "views/")
-	templates := g.Section("templates")
+	templates := g.Section("views")
 	load(root, views, templates)
 }

--- a/internal/skeleton/assets/handlers/app.go
+++ b/internal/skeleton/assets/handlers/app.go
@@ -143,13 +143,6 @@ func (t tApp) PostGreet(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Init is used to initialize controllers of "github.com/colegion/goal/internal/skeleton/controllers"
-// and its parents.
-func Init(g config.Getter) {
-	initApp(g)
-	initControllers(g)
-}
-
 func initApp(g config.Getter) {
 }
 

--- a/internal/skeleton/assets/handlers/controllers.go
+++ b/internal/skeleton/assets/handlers/controllers.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	c0 "github.com/colegion/goal/internal/skeleton/assets/handlers/github.com/colegion/goal/controllers/requests"
-	c2 "github.com/colegion/goal/internal/skeleton/assets/handlers/github.com/colegion/goal/controllers/sessions"
 	c1 "github.com/colegion/goal/internal/skeleton/assets/handlers/github.com/colegion/goal/controllers/templates"
+	c2 "github.com/colegion/goal/internal/skeleton/assets/handlers/github.com/colegion/goal/controllers/sessions"
 	contr "github.com/colegion/goal/internal/skeleton/controllers"
 
 	"github.com/colegion/goal/config"
@@ -102,6 +102,13 @@ func (t tControllers) Finally(c *contr.Controllers, w http.ResponseWriter, r *ht
 		return finish
 	}
 	return
+}
+
+// Init is used to initialize controllers of "github.com/colegion/goal/internal/skeleton/controllers"
+// and its parents.
+func Init(g config.Getter) {
+	initApp(g)
+	initControllers(g)
 }
 
 func initControllers(g config.Getter) {

--- a/internal/skeleton/assets/views/views.go
+++ b/internal/skeleton/assets/views/views.go
@@ -1,4 +1,4 @@
-// Package views is generated automatically by goal toolkit.
+// Package views is generated automatically.
 // Please, do not edit it manually.
 package views
 

--- a/internal/skeleton/assets/views/views.ini
+++ b/internal/skeleton/assets/views/views.ini
@@ -1,6 +1,6 @@
 ; This configuration file is generated automatically.
 ; Please, DO NOT EDIT IT MANUALLY.
-[templates]
+[views]
 App.GreetHTML = App/Greet.html
 App.IndexHTML = App/Index.html
 BaseHTML = Base.html

--- a/internal/skeleton/controllers/init.go
+++ b/internal/skeleton/controllers/init.go
@@ -15,6 +15,12 @@ import (
 //
 //go:generate goal generate handlers --input ./ --output ../assets/handlers
 
+// The line below tells golang's generate command you want
+// it to scan your views and generate a listing.
+// Please, do not delete it unless you know what you are doing.
+//
+//go:generate goal generate listing --input ../views --output ../assets/views
+
 // Controllers is a struct that should be embedded into every controller
 // of your app to make methods and fields provided by standard controllers available.
 type Controllers struct {

--- a/internal/skeleton/goal.yml
+++ b/internal/skeleton/goal.yml
@@ -27,7 +27,7 @@ watch:
   # "*" at the end of path means watch recursively.
   # Empty tasks are not allowed.
   ./controllers/*:
-    - go generate ./controllers/init.go
+    - go generate ./controllers
     - /start get
     - /run build
     - /single start

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/colegion/goal/log"
 	"github.com/colegion/goal/tools/create"
 	"github.com/colegion/goal/tools/generate/handlers"
+	"github.com/colegion/goal/tools/generate/listing"
 	"github.com/colegion/goal/tools/run"
 )
 
@@ -23,6 +24,7 @@ var tools = command.NewContext(
 	run.Handler,
 
 	handlers.Handler,
+	listing.Handler,
 )
 
 func main() {

--- a/tools/generate/handlers/main.go
+++ b/tools/generate/handlers/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/colegion/goal/internal/command"
 )
 
-// Handler is an instance of "new" subcommand (tool).
+// Handler is an instance of "generate handlers" subcommand (tool).
 var Handler = command.Handler{
 	Run: main,
 

--- a/tools/generate/listing/listing.go.template
+++ b/tools/generate/listing/listing.go.template
@@ -1,0 +1,55 @@
+// Package <@.package> is generated automatically by Sunplate toolkit.
+// Please, do not edit it manually.
+package <@.package>
+
+// Root is a directory where templates are located.
+var Root = "<@.ctx.input>"
+
+// List is a list of files that were found at "<@.ctx.input>"
+// in a form of slice of strings.
+var List []string
+
+// Paths stores information about all files that
+// were found at "<@.ctx.input>".
+var Paths tPaths
+
+// tPaths represents a root directory with files.
+type tPaths struct {
+	//
+	// Below are the assets of root directory.
+	//
+:	<@template "rangePaths" .ctx.listing.RootAssets>
+}
+
+<@range $name, $paths := .ctx.listing.Dirs>\
+:	// t<@$name> is a type that represents a directory.
+:	type tPath<@$name> struct {
+:		//
+:		// Below are the assets of this directory.
+:		//
+:	:	<@template "rangePaths" $paths>
+:	}
+
+<@end>\
+\
+func init() {
+:	<@range $file, $path := .ctx.listing.FilePaths>\
+:		Paths.<@$file> = "<@$path>"
+:	<@end>\
+	List = []string{ // Make file paths available in a form of slice of strings.
+:	:	<@range $file, $path := .ctx.listing.FilePaths>\
+:			Paths.<@$file>,
+:	:	<@end>\
+	}
+}
+<@define "rangePaths">\
+:	<@range $i, $path := .>\
+:	:	<@if $path.Dir>
+:	:		// <@$path.Name> is a "<@$path.String>" directory.
+:	:		<@$path.Name> tPath<@$path.DirStructName>\
+:	:	<@else>
+:	:		// <@$path.Name> is a "<@$path.String>" file.
+:	:		<@$path.Name> string\
+:	:	<@end>\
+:	<@end>\
+<@end>\

--- a/tools/generate/listing/listing.go.template
+++ b/tools/generate/listing/listing.go.template
@@ -1,4 +1,4 @@
-// Package <@.package> is generated automatically by Sunplate toolkit.
+// Package <@.package> is generated automatically.
 // Please, do not edit it manually.
 package <@.package>
 

--- a/tools/generate/listing/listing.ini.template
+++ b/tools/generate/listing/listing.ini.template
@@ -1,0 +1,6 @@
+; This configuration file is generated automatically.
+; Please, DO NOT EDIT IT MANUALLY.
+[<@.package>]
+<@range $file, $path := .ctx.listing.FilePaths>\
+:	<@$file> = <@$path>
+<@end>\

--- a/tools/generate/listing/main.go
+++ b/tools/generate/listing/main.go
@@ -1,0 +1,138 @@
+// Package listing is a subcommand of generate that is
+// used for scanning directories and composing a list
+// of found files. It may be useful to statically check
+// names of used templates.
+// I.e. instead of using paths of templates in actions
+// directely like `RenderTemplate("path/to/template.html")`,
+// it is possible to do something like
+// `RenderTemplate(views.Path.To.TemplateHTML)`.
+package listing
+
+import (
+	"fmt"
+	"go/ast"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/colegion/goal/internal/command"
+	"github.com/colegion/goal/internal/generation"
+	p "github.com/colegion/goal/internal/path"
+	"github.com/colegion/goal/log"
+)
+
+var fileNamePattern = regexp.MustCompile(
+	"^[A-Za-z]{1}\\w*[.]{0,1}\\w*$",
+)
+
+// Handler is an instance of "generate listing" subcommand (tool).
+var Handler = command.Handler{
+	Run: main,
+
+	Name:  "generate listing",
+	Usage: "[flags]",
+	Info:  "generate a listing of files and directories",
+	Desc: `Tool "generate listing" scans the directory you request
+and generates a package with file names that were found.
+So, you can import and use the generated package as follows:
+
+	listing.Paths.Some.Path.To.FileHTML
+
+The variable above is a string containing a path to that file.
+The advantage of this approach is type safety. If this tool is started
+every time you modify your files it will garantee you are not using
+a template that does not exist.
+`,
+}
+
+var input, output, pkg *string
+
+// main is an entry point of listing subcommand.
+func main(hs []command.Handler, i int, args command.Data) {
+	// Prepare a path to scan.
+	path, err := p.New(*input).Absolute()
+	log.AssertNil(err)
+
+	// Start search of files.
+	fs, fn := walkFunc(path.String())
+	filepath.Walk(path.String(), fn)
+
+	// Generate and save a new package.
+	tpl, err := p.New("github.com/colegion/goal/tools/generate/listing/listing.go.template").Package()
+	log.AssertNil(err)
+	t := generation.NewType(*pkg, tpl.String())
+	t.CreateDir(*output)
+	t.Extension = ".go" // Save generated file as a .go source.
+	t.Context = map[string]interface{}{
+		"listing": fs,
+		"input":   *input,
+	}
+	t.Generate()
+
+	// Generate and save ini config with file names.
+	tpl, err = p.New("github.com/colegion/goal/tools/generate/listing/listing.ini.template").Package()
+	log.AssertNil(err)
+	t.Path = *output
+	t.Extension = ".ini"
+	t.Context = map[string]interface{}{
+		"listing": fs,
+		"input":   *input,
+	}
+	t.Generate()
+}
+
+// walkFunc returns a files listing and a function that may be used for validation
+// of found files. Successfully validated ones are stored to the listing variable.
+func walkFunc(dir string) (listing, func(string, os.FileInfo, error) error) {
+	l := listing{}
+
+	return l, func(path string, info os.FileInfo, err error) error {
+		// Make sure there are no any errors.
+		if err != nil {
+			log.Warn.Printf(`An error occured while creating a listing: "%s".`, err)
+			return err
+		}
+
+		// Get filepath without the dir path at the beginning.
+		// So, when we are scanning "views/app/index.html" our generated
+		// result will be "app/index.html" instead.
+		rel, _ := filepath.Rel(dir, path)
+
+		// Make sure file name is of supported format.
+		ss := strings.Split(rel, string(filepath.Separator))
+		for _, s := range ss {
+			// Ignore root directory.
+			if s == "." {
+				continue
+			}
+
+			// Check whether file / directory name is supported.
+			if !fileNamePattern.MatchString(s) {
+				log.Warn.Printf(`"%s" is ignored as "%s" is of unsupported format.`, rel, s)
+				return fmt.Errorf(`"%s" is of unsupported type`, s)
+			}
+
+			// Notify user if file / directory's name is not exported.
+			if !ast.IsExported(s) {
+				log.Trace.Printf(`"%s" will not be exported as "%s" starts with a lower case letter.`, rel, s)
+			}
+		}
+
+		// Add the directory to the list (if it is a dir).
+		if info.IsDir() {
+			l.addDir(rel)
+			return nil
+		}
+
+		// Otherwise, register the file.
+		l.addFile(rel)
+		return nil
+	}
+}
+
+func init() {
+	input = Handler.Flags.String("input", "./views", "a path to directory with files to scan")
+	output = Handler.Flags.String("output", "./assets/views", "a directory where generated package must be saved")
+	pkg = Handler.Flags.String("package", "views", "name of the package to generate")
+}

--- a/tools/generate/listing/main.go
+++ b/tools/generate/listing/main.go
@@ -66,18 +66,19 @@ func main(hs []command.Handler, i int, args command.Data) {
 	t.Extension = ".go" // Save generated file as a .go source.
 	t.Context = map[string]interface{}{
 		"listing": fs,
-		"input":   *input,
+		"input":   filepath.ToSlash(*input),
 	}
 	t.Generate()
 
 	// Generate and save ini config with file names.
 	tpl, err = p.New("github.com/colegion/goal/tools/generate/listing/listing.ini.template").Package()
 	log.AssertNil(err)
+	t = generation.NewType(*pkg, tpl.String())
 	t.Path = *output
 	t.Extension = ".ini"
 	t.Context = map[string]interface{}{
 		"listing": fs,
-		"input":   *input,
+		"input":   filepath.ToSlash(*input),
 	}
 	t.Generate()
 }

--- a/tools/generate/listing/main_test.go
+++ b/tools/generate/listing/main_test.go
@@ -1,0 +1,84 @@
+package listing
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/colegion/goal/internal/command"
+)
+
+var handlers []command.Handler
+
+func init() {
+	Handler.Flags.Set("input", "./testdata/views")
+	Handler.Flags.Set("output", "./testdata/assets/views")
+
+	handlers = []command.Handler{Handler}
+}
+
+func TestStart(t *testing.T) {
+	main(handlers, 0, []string{})
+
+	// This function is tested on the level of "generation" package.
+
+	// Remove the directory we have created.
+	os.RemoveAll("../testdata/assets")
+}
+
+func TestWalkFunc(t *testing.T) {
+	l, fn := walkFunc("")
+	TestError := errors.New("this is a test error")
+	if err := fn("", nil, TestError); err != TestError {
+		t.Errorf(`walkFunc expected to return TestError, returned "%s".`, err)
+	}
+
+	err := fn("views/привет/myfile.txt", testFile{}, nil)
+	if err == nil {
+		t.Errorf("Incorrect directory name. Error expected, got nil.")
+	}
+
+	err = fn("views/myfile.data.txt", testFile{}, nil)
+	if err == nil {
+		t.Errorf("Incorrect directory name. Error expected, got nil.")
+	}
+
+	err = fn("views/index.html", testFile{}, nil)
+	if err != nil {
+		t.Errorf("Correct name. Nil expected, got error: %v.", err)
+	}
+
+	err = fn("./", testFile{}, nil)
+	if err != nil {
+		t.Errorf("Correct name. Nil expected, got error: %v.", err)
+	}
+
+	l, fn = walkFunc("views")
+	fn("views/app/myfile.txt", testFile{}, nil)
+	if len(l) == 0 || len(l["app"]) != 1 || l["app"][0].Name() != "myfileTXT" {
+		t.Errorf("Failed to add a new path to the listing: %#v.", l)
+	}
+
+	l, fn = walkFunc("./views")
+	fn("views/app", testFile{dir: true}, nil)
+	if len(l) != 1 || len(l[""]) != 1 || l[""][0].Name() != "app" {
+		t.Errorf("Failed to add a dir path to the listing: %#v.", l)
+	}
+
+	fn("views/app/myfile.txt", testFile{}, nil)
+	if len(l) != 2 || len(l["app"]) != 1 || l["app"][0].Name() != "myfileTXT" {
+		t.Errorf("Failed to add a file path to the listing: %#v.", l)
+	}
+}
+
+type testFile struct {
+	dir bool
+}
+
+func (t testFile) Name() string       { return "test" }
+func (t testFile) Size() int64        { return 0 }
+func (t testFile) Mode() os.FileMode  { return os.ModeTemporary }
+func (t testFile) ModTime() time.Time { return time.Now() }
+func (t testFile) IsDir() bool        { return t.dir }
+func (t testFile) Sys() interface{}   { return nil }

--- a/tools/generate/listing/paths.go
+++ b/tools/generate/listing/paths.go
@@ -1,0 +1,161 @@
+package listing
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// listing is a map of all found paths. Key is a string
+// representation of directory path, values are files found in
+// those directories.
+type listing map[string][]path
+
+// path represents a path to some file.
+type path struct {
+	Value []string // E.g. "path/to/smth" will be {"path", "to", "smth"}.
+	Dir   bool     // Is it a path of a directory or a file.
+}
+
+// Name returns a name of the file / directory.
+// File's name is the last segment of file with
+// upper cased extension without a dot.
+func (p path) Name() string {
+	// Otherwise, get the last element of path (Base).
+	n := p.Value[len(p.Value)-1]
+
+	// Cut extension, translate it to upper case,
+	// and concatenate again.
+	ext := filepath.Ext(n)
+	n = n[:len(n)-len(ext)]
+	if len(ext) != 0 {
+		ext = ext[1:] // Trim dot at the beginning
+	}
+	n += strings.ToUpper(ext)
+
+	return n
+}
+
+// DirStructName returns a value that may be
+// used for a name of a directory structure.
+// Directory's name consists of segments
+// concatenated without separators.
+func (p path) DirStructName() string {
+	if p.Dir {
+		return strings.Join(p.Value, "")
+	}
+	return ""
+}
+
+// String returns a path of a file / directory as a string.
+func (p path) String() string {
+	return filepath.ToSlash(filepath.Join(p.Value...))
+}
+
+// addFile gets a path to some file as a string
+// and registers it.
+func (l listing) addFile(file string) {
+	// Split path into segments and get a dir name (opposite of Base).
+	ss := strings.Split(filepath.ToSlash(file), "/")
+	dir := filepath.ToSlash(filepath.Join(ss[:len(ss)-1]...)) // If path is "path/to/smth.txt", use "path/to".
+
+	// Check whether such path already exists.
+	if _, ok := l[dir]; !ok {
+		// If not, initialize it.
+		l[dir] = []path{}
+	}
+
+	// Add the file to listing.
+	l[dir] = append(l[dir], path{
+		Value: ss,
+		Dir:   false,
+	})
+}
+
+// addDir is identical to addFile except it is for
+// directories rather than files.
+func (l listing) addDir(dir string) {
+	// Make sure path is not empty.
+	if dir == "" || dir == "." {
+		return
+	}
+
+	// Split path into segments and get a root dir name (opposite of Base).
+	ss := strings.Split(filepath.ToSlash(dir), "/")
+	root := filepath.ToSlash(filepath.Join(ss[:len(ss)-1]...)) // If path is "path/to/dir", use "path/to".
+
+	// Check whether such path already exists.
+	if _, ok := l[root]; !ok {
+		// If not, initialize it.
+		l[root] = []path{}
+	}
+
+	// Add the directory to the list.
+	l[root] = append(l[root], path{
+		Value: ss,
+		Dir:   true,
+	})
+}
+
+// FilePaths returns a map of file name - file path pairs.
+// Example of a name is "Path.To.FileHTML".
+// It is used in template for generation of initialization
+// function.
+func (l listing) FilePaths() map[string]string {
+	fs := map[string]string{}
+	for _, p := range l.paths() {
+		// Make sure the path does not belong to directory.
+		if p.Dir {
+			continue
+		}
+
+		// Prepare a name of the variable that will be
+		// used for storing file's path.
+		n := p.Name()
+		if len(p.Value) > 1 {
+			n = fmt.Sprintf(
+				"%s.%s",
+				strings.Join(p.Value[:len(p.Value)-1], "."),
+				n,
+			)
+		}
+
+		fs[n] = p.String()
+	}
+	return fs
+}
+
+// Dirs a map of directory name - a list of paths inside
+// pairs. Examples of names are: "App", "AppProfile", etc.
+// It is used in template to generate types for directories.
+// Dirs does not return root directory ("./").
+func (l listing) Dirs() map[string][]path {
+	ds := map[string][]path{}
+	for _, p := range l.paths() {
+		// Ignore files.
+		if !p.Dir {
+			continue
+		}
+
+		// Add the current directory and its
+		// children.
+		ds[p.DirStructName()] = l[p.String()]
+	}
+	return ds
+}
+
+// RootAssets returns a list of directories and files
+// that are found at the root of requested path.
+// This method is used in template.
+func (l listing) RootAssets() (ps []path) {
+	return l[""]
+}
+
+// paths returns all paths of listing in a flat form:
+// as a slice.
+func (l listing) paths() (ps []path) {
+	for _, paths := range l {
+		ps = append(ps, paths...)
+	}
+	return
+}

--- a/tools/generate/listing/paths_test.go
+++ b/tools/generate/listing/paths_test.go
@@ -1,0 +1,158 @@
+package listing
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPathName(t *testing.T) {
+	inp := []path{
+		{Value: []string{"path", "to", "some", "file.txt"}},
+		{Value: []string{"file"}},
+		{Value: []string{"app"}, Dir: true},
+		{Value: []string{"Path", "To", "Dir"}, Dir: true},
+	}
+	exp := []string{"fileTXT", "file", "app", "Dir"}
+	for i, p := range inp {
+		if r := p.Name(); r != exp[i] {
+			t.Errorf(`Incorrect result with path "%s". Expected "%s", got "%s".`, p, exp[i], r)
+		}
+	}
+}
+
+func TestPathDirStructName(t *testing.T) {
+	inp := []path{
+		{Value: []string{"file"}},
+		{Value: []string{"app"}, Dir: true},
+		{Value: []string{"Path", "To", "Dir"}, Dir: true},
+	}
+	exp := []string{"", "app", "PathToDir"}
+	for i, p := range inp {
+		if r := p.DirStructName(); r != exp[i] {
+			t.Errorf(`Incorrect result with path "%s". Expected "%s", got "%s".`, p, exp[i], r)
+		}
+	}
+}
+
+func TestListingAddFile(t *testing.T) {
+	f := "path/to/some/dir/file.txt"
+	f1 := "path/to/some/file.txt"
+	f2 := "root.txt"
+	f3 := "root1.txt"
+	f4 := "path/to/some/file1.txt"
+
+	l := listing{}
+	l.addFile(f1)
+	l.addFile(f2)
+	l.addFile(f3)
+	l.addFile(f4)
+	l.addFile(f)
+
+	r, ok := l["path/to/some/dir"]
+	if !ok {
+		t.Errorf(`File "%s" was not added: %#v.`, f, l)
+	}
+
+	if len(r) != 1 || len(r[0].Value) != 5 || r[0].Name() != "fileTXT" {
+		t.Errorf(`File "%s" ("%s") was added incorrectly: %#v.`, f, r[0].Name(), l)
+	}
+
+	r, ok = l[""]
+	if !ok {
+		t.Errorf(`File "%s" was not added: %#v.`, f3, l)
+	}
+
+	if len(r) != 2 || r[0].Name() != "rootTXT" || r[1].Name() != "root1TXT" {
+		t.Errorf(`Files "%s" and "%s" were added incorrectly: %#v.`, f2, f3, l)
+	}
+
+	r, ok = l["path/to/some"]
+	if !ok {
+		t.Errorf(`File "%s" was not added: %#v.`, f4, l)
+	}
+
+	if len(r) != 2 || r[0].Name() != "fileTXT" || r[1].Name() != "file1TXT" {
+		t.Errorf(`Files "%s" and "%s" were added incorrectly: %#v.`, f1, f4, l)
+	}
+}
+
+func TestPathString(t *testing.T) {
+	f := path{Value: []string{"path", "to", "something"}, Dir: true}
+	exp := "path/to/something"
+	if r := f.String(); r != exp {
+		t.Errorf(`Incorrect path to the file. Expected "%s", got "%s".`, exp, r)
+	}
+}
+
+func TestListingFilePaths(t *testing.T) {
+	l := listing{}
+	l.addDir(".")
+	l.addFile("Base.html")
+	l.addDir("Path/To/Dir")
+	l.addFile("Path/To/Dir/Index.html")
+	l.addDir("Path/To/Dir/Subdir")
+	l.addFile("Path/To/Dir/Subdir/Index.html")
+
+	exp := map[string]string{
+		"BaseHTML":                     "Base.html",
+		"Path.To.Dir.IndexHTML":        "Path/To/Dir/Index.html",
+		"Path.To.Dir.Subdir.IndexHTML": "Path/To/Dir/Subdir/Index.html",
+	}
+	if r := l.FilePaths(); !reflect.DeepEqual(r, exp) {
+		t.Errorf(`Incorrect values of paths. Expected "%s", got "%s".`, exp, r)
+	}
+}
+
+func TestListingDirs(t *testing.T) {
+	l := listing{}
+	l.addDir(".")
+	l.addFile("Base.html")
+	l.addDir("Path")
+	l.addDir("Path/To")
+	l.addDir("Path/To/Dir")
+	l.addFile("Path/To/Dir/Index.html")
+	l.addFile("Path/To/Dir/Index2.html")
+	l.addDir("Path/To/Dir/Subdir")
+	l.addFile("Path/To/Dir/Subdir/Index.html")
+
+	exp := map[string][]path{
+		"Path": {
+			{Value: []string{"Path", "To"}, Dir: true},
+		},
+		"PathTo": {
+			{Value: []string{"Path", "To", "Dir"}, Dir: true},
+		},
+		"PathToDir": {
+			{Value: []string{"Path", "To", "Dir", "Index.html"}, Dir: false},
+			{Value: []string{"Path", "To", "Dir", "Index2.html"}, Dir: false},
+			{Value: []string{"Path", "To", "Dir", "Subdir"}, Dir: true},
+		},
+		"PathToDirSubdir": {
+			{Value: []string{"Path", "To", "Dir", "Subdir", "Index.html"}, Dir: false},
+		},
+	}
+	if r := l.Dirs(); !reflect.DeepEqual(r, exp) {
+		t.Errorf(`Incorrect values of dirs. Expected "%s", got "%s".`, exp, r)
+	}
+}
+
+func TestListingRootAssets(t *testing.T) {
+	l := listing{}
+	l.addDir(".")
+	l.addFile("Base.html")
+	l.addDir("Path")
+	l.addDir("Path/To")
+	l.addDir("Path/To/Dir")
+	l.addFile("Path/To/Dir/Index.html")
+	l.addFile("Path/To/Dir/Index2.html")
+	l.addDir("Path/To/Dir/Subdir")
+	l.addFile("Path/To/Dir/Subdir/Index.html")
+
+	exp := []path{
+		{Value: []string{"Base.html"}, Dir: false},
+		{Value: []string{"Path"}, Dir: true},
+	}
+	if r := l.RootAssets(); !reflect.DeepEqual(r, exp) {
+		t.Errorf(`Incorrect values of root directory assets. Expected "%s", got "%s".`, exp, r)
+	}
+}

--- a/tools/generate/listing/testdata/assets/views/views.go
+++ b/tools/generate/listing/testdata/assets/views/views.go
@@ -1,0 +1,27 @@
+// Package views is generated automatically by Sunplate toolkit.
+// Please, do not edit it manually.
+package views
+
+// Root is a directory where templates are located.
+var Root = "./testdata/views"
+
+// List is a list of files that were found at "./testdata/views"
+// in a form of slice of strings.
+var List []string
+
+// Paths stores information about all files that
+// were found at "./testdata/views".
+var Paths tPaths
+
+// tPaths represents a root directory with files.
+type tPaths struct {
+	//
+	// Below are the assets of root directory.
+	//
+
+}
+
+func init() {
+	List = []string{ // Make file paths available in a form of slice of strings.
+	}
+}

--- a/tools/generate/listing/testdata/assets/views/views.ini
+++ b/tools/generate/listing/testdata/assets/views/views.ini
@@ -1,0 +1,27 @@
+// Package views is generated automatically by Sunplate toolkit.
+// Please, do not edit it manually.
+package views
+
+// Root is a directory where templates are located.
+var Root = "./testdata/views"
+
+// List is a list of files that were found at "./testdata/views"
+// in a form of slice of strings.
+var List []string
+
+// Paths stores information about all files that
+// were found at "./testdata/views".
+var Paths tPaths
+
+// tPaths represents a root directory with files.
+type tPaths struct {
+	//
+	// Below are the assets of root directory.
+	//
+
+}
+
+func init() {
+	List = []string{ // Make file paths available in a form of slice of strings.
+	}
+}


### PR DESCRIPTION
This PR reverts the changes made for #1.

Currently, controllers have a pretty simple definition: any type that has (1) actions or (2) magic methods.

1. Action is a method that returns `http.Handler` as the first argument.
2. Magic methods are:
  * Before and After actions;
  * Initially and Finally methods:
```go
func (c Controller) Initially(w http.ResponseWriter, r *http.Request) bool {
}
```

#1 will require us to rethink the definition of controllers and rewrite the `generate/handlers` tool. I want to think it over before making further changes. Probably, two approaches will be used simultaneously, not sure yet.