### PR TITLE
Add utils package to the skeleton application

### DIFF
--- a/internal/skeleton/main.go
+++ b/internal/skeleton/main.go
@@ -6,27 +6,16 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/colegion/goal/internal/skeleton/assets/handlers"
-	"github.com/colegion/goal/internal/skeleton/routes"
+	"github.com/colegion/goal/internal/skeleton/utils"
 
-	"github.com/colegion/contrib/configs/iniflag"
 	"github.com/colegion/contrib/servers/grace"
 )
 
 var addr = flag.String("http.addr", ":8080", "address the application will listen on")
 
 func main() {
-	// Parse configuration files and flags.
-	err := iniflag.Parse("config/config.ini")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Initialization of handlers.
-	handlers.Init()
-
-	// Build the routes and handler.
-	handler, err := routes.List.Build()
+	// Initialize app's HTTP handler.
+	handler, err := utils.InitHandler("config/config.ini")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/skeleton/utils/utils.go
+++ b/internal/skeleton/utils/utils.go
@@ -1,0 +1,38 @@
+// Package utils provides building blocks that are reused across
+// the application (e.g. in tests and main package) but are not related
+// to the business logics. Everything that is used for initialization and
+// start of the app but hasn't got its own package must be located here.
+package utils
+
+import (
+	"net/http"
+
+	"github.com/colegion/goal/internal/skeleton/assets/handlers"
+	"github.com/colegion/goal/internal/skeleton/routes"
+
+	"github.com/colegion/contrib/configs/iniflag"
+)
+
+// InitHandler gets a number of INI configuration file paths.
+// It parses them, populates flags with the data extracted from the configs
+// and input arguments to the program, and returns an initialized
+// go HTTP handler that is based on the app's routes and handler functions
+// automatically generated from controllers.
+// Example:
+//	h, err := InitHandler("basic.ini", "more/important.ini", "most/important.ini")
+//	if err != nil {
+//		panic(err)
+//	}
+func InitHandler(configFiles ...string) (http.Handler, error) {
+	// Parse configuration files and flags.
+	err := iniflag.Parse(configFiles...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize handler functions and controllers.
+	handlers.Init()
+
+	// Build a standard HTTP handler from routes and handler functions.
+	return routes.List.Build()
+}


### PR DESCRIPTION
The part related to the initialization of handler functions and controllers + build of routes is repeated both in the `main` package and tests of controllers. So it was extracted into its own package `utils`.