### PR TITLE
fix new Controller instance is failed

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -51,32 +51,32 @@ type Route struct {
 func (ps Prefixes) ParseRoutes(controller string, f *r.Func) (rs []Route) {
 	for i := range f.Comments {
 		// Skip comments that do not contain routes.
-		m, p, l, ok := parseComment(f.Comments[i])
+		method, pattern, label, ok := parseComment(f.Comments[i])
 		if !ok {
 			continue
 		}
 
 		// If no pattern specified, use controller's and action's names.
-		if p == "" {
-			p = path.Join("/", controller, f.Name)
+		if pattern == "" {
+			pattern = path.Join("/", controller, f.Name)
 		}
 
 		// Concatenate route with every of the prefixes
 		// if their methods match.
 		for j := range ps {
 			// Ignore prefixes which's methods do not match and they are not wildcard.
-			if ps[j].Method != m && ps[j].Method != wildcardRoute {
+			if ps[j].Method != method && ps[j].Method != wildcardRoute {
 				continue
 			}
 
 			// Concatenate all other prefixes and add to the list.
-			ms := realMethods(m)
+			ms := realMethods(method)
 			for k := range ms {
 				r := Route{
 					Method:      ms[k],
-					Pattern:     path.Join(ps[j].Pattern, p),
+					Pattern:     path.Join(ps[j].Pattern, pattern),
 					HandlerName: controller + "." + f.Name,
-					Label:       l,
+					Label:       label,
 				}
 				log.Trace.Printf(
 					`Detected route "%s" "%s" "%s" ("%s")`, r.Method, r.Pattern, r.HandlerName, r.Label,

--- a/tools/generate/handlers/parents.go
+++ b/tools/generate/handlers/parents.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 )
 
 // parents represents a set of relative controllers.
@@ -100,14 +102,15 @@ func (pcs parentControllers) Reverse() (res parentControllers) {
 //	uniqueName1 "some/import/path/2"
 //	...
 func (pcs parentControllers) Imports() string {
-	res := ""
+	results := make([]string, 0, len(pcs))
 	for i := range pcs {
 		// Ignore repeated packages and the main one (with empty accessor).
 		if pcs[i].instance == "" && pcs[i].Accessor != "" {
-			res += fmt.Sprintf(`%s "%s"%s`, pcs[i].Accessor, pcs[i].Controller.Parents.childImport, "\n")
+			results = append(results, fmt.Sprintf(`%s "%s"`, pcs[i].Accessor, pcs[i].Controller.Parents.childImport))
 		}
 	}
-	return res
+	sort.Strings(results)
+	return strings.Join(results, "\n") + "\n"
 }
 
 // All returns all parent controllers of a controller including

--- a/tools/run/main.go
+++ b/tools/run/main.go
@@ -78,7 +78,7 @@ func main(hs []tool.Handler, i int, args tool.Data) {
 			action: "exit",
 		}
 		<-stopped
-		log.Trace.Panicln("Application has been terminated.")
+		log.Trace.Fatalln("Application has been terminated.")
 	}()
 
 	// Execute all commands from the requested directory.


### PR DESCRIPTION
old code is
````go
func (t tControllers) newC(w http.ResponseWriter, r *http.Request, ctr, act string) *contr.Controllers {
	// Allocate a new controller. Set values of special fields, if necessary.
	c := &contr.Controllers{}

	// Allocate its parents. Make sure controller of every type
	// is allocated just once, then reused.
	c.Templates = c.Errors.Templates
	c.Errors = &c5.Errors{}
	c.Static = &c3.Static{}
	c.Sessions = &c2.Sessions{

		Request: r,

		Response: w,
	}
	c.Requests = &c1.Requests{

		Request: r,

		Response: w,
	}
	c.Global = &c0.Global{

		CurrentAction: act,

		CurrentController: ctr,
	}
	c.Errors.Templates = &c4.Templates{}
	c.Errors.Templates.Requests = c.Requests
	c.Errors.Templates.Global = c.Global
	c.Templates.Requests = c.Requests
	c.Templates.Global = c.Global

	return c
}
````


new code is
````go

func (t tControllers) newC(w http.ResponseWriter, r *http.Request, ctr, act string) *contr.Controllers {
	// Allocate a new controller. Set values of special fields, if necessary.
	c := &contr.Controllers{}

	// Allocate its parents. Make sure controller of every type
	// is allocated just once, then reused.
	c.Templates = &c4.Templates{}
	c.Errors = &c5.Errors{}
	c.Static = &c3.Static{}
	c.Sessions = &c2.Sessions{

		Request: r,

		Response: w,
	}
	c.Requests = &c1.Requests{

		Request: r,

		Response: w,
	}
	c.Global = &c0.Global{

		CurrentAction: act,

		CurrentController: ctr,
	}
	c.Errors.Templates = c.Templates
	c.Templates.Requests = c.Requests
	c.Templates.Global = c.Global

	return c
}
````